### PR TITLE
issue #4 fix mobile layout

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1741705543807
+		"lastUpdateCheck": 1748764593431
 	}
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -35,7 +35,7 @@ const { title } = Astro.props;
     --accent-color: #7c3aed;
     --card-bg: rgba(255, 255, 255, 0.1);
   }
-  
+
   html {
     font-family: system-ui, sans-serif;
     background: var(--bg-color);
@@ -106,6 +106,13 @@ const { title } = Astro.props;
     margin: 0.5rem 0 0;
     opacity: 0.9;
   }
+
+  @media only screen and (max-width: 600px) {
+  .bento-grid {
+      display: flex;
+      flex-direction: column;
+  }
+}
 
   @keyframes fadeInUp {
     to {


### PR DESCRIPTION
#### Settings update:

Updated the `lastUpdateCheck` variable to a new timestamp.

#### Responsive design improvement:

Added a media query to make the `.bento-grid` class display as a column on screens with a maximum width of 600px.

![image](https://github.com/user-attachments/assets/d12dc0fe-5ff2-4e1d-bce5-7bd929749a5b)
